### PR TITLE
feat: Truncate input schema, limit description to 200 characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ For example it can:
 - use [Instagram Scraper](https://apify.com/apify/instagram-scraper) to scrape Instagram posts, profiles, places, photos, and comments
 - use [RAG Web Browser](https://apify.com/apify/web-scraper) to search the web, scrape the top N URLs, and return their content
 
-To interact with the Apify MCP server, you can use MCP clients such as [Claude Desktop](https://claude.ai/download), [Superinference.ai](https://superinterface.ai/), or [LibreChat](https://www.librechat.ai/).
+
+To interact with the Apify MCP server, you can use MCP clients such as [Claude Desktop](https://claude.ai/download), [LibreChat](https://www.librechat.ai/), or other [MCP clients](https://glama.ai/mcp/clients).
 Additionally, you can use simple example clients found in the [examples](https://github.com/apify/actor-mcp-server/tree/main/src/examples) directory.
 
 When you have Actors integrated with the MCP server, you can ask:
@@ -28,6 +29,10 @@ When you have Actors integrated with the MCP server, you can ask:
 - "Find and analyze Instagram profile of The Rock"
 - "Provide a step-by-step guide on using the Model Context Protocol with source URLs."
 - "What Apify Actors I can use?"
+
+The following image shows how the Apify MCP server interacts with the Apify platform and AI clients:
+
+![Actors-MCP-server](https://raw.githubusercontent.com/apify/actors-mcp-server/refs/heads/master/docs/actors-mcp-server.png)
 
 In the future, we plan to load Actors dynamically and provide Apify's dataset and key-value store as resources.
 See the [Roadmap](#-roadmap-january-2025) for more details.
@@ -311,11 +316,14 @@ Upon launching, the Inspector will display a URL that you can access in your bro
 To limit the context size the properties in the `input schema` are pruned and description is truncated to 200 characters.
 Enum fields and titles are truncated to max 50 options.
 
+Memory for each Actor is limited to 4GB.
+Free users have an 8GB limit, 128MB needs to be allocated for running `Actors-MCP-Server`.
+
 If you need other features or have any feedback, please [submit an issue](https://console.apify.com/actors/3ox4R101TgZz67sLr/issues) in Apify Console to let us know.
 
 # 🚀 Roadmap (January 2025)
 
-- Document examples for [Superinference.ai](https://superinterface.ai/) and [LibreChat](https://www.librechat.ai/).
+- Document examples for [LibreChat](https://www.librechat.ai/).
 - Provide tools to search for Actors and load them as needed.
 - Add Apify's dataset and key-value store as resources.
 - Add tools such as Actor logs and Actor runs for debugging.

--- a/README.md
+++ b/README.md
@@ -301,10 +301,17 @@ npm run build
 You can launch the MCP Inspector via [`npm`](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) with this command:
 
 ```bash
-npx @modelcontextprotocol/inspector node /path/to/actor-mcp-server/dist/index.js --env APIFY_TOKEN=your-apify-token
+npx @modelcontextprotocol/inspector node @apify/actors-mcp-server --env APIFY_TOKEN=your-apify-token
 ```
 
 Upon launching, the Inspector will display a URL that you can access in your browser to begin debugging.
+
+## ⓘ Limitations and feedback
+
+To limit the context size the properties in the `input schema` are pruned and description is truncated to 200 characters.
+Enum fields and titles are truncated to max 50 options.
+
+If you need other features or have any feedback, please [submit an issue](https://console.apify.com/actors/3ox4R101TgZz67sLr/issues) in Apify Console to let us know.
 
 # 🚀 Roadmap (January 2025)
 
@@ -312,4 +319,3 @@ Upon launching, the Inspector will display a URL that you can access in your bro
 - Provide tools to search for Actors and load them as needed.
 - Add Apify's dataset and key-value store as resources.
 - Add tools such as Actor logs and Actor runs for debugging.
-- Prune Actors input schema to reduce context size.

--- a/README.md
+++ b/README.md
@@ -321,6 +321,9 @@ Free users have an 8GB limit, 128MB needs to be allocated for running `Actors-MC
 
 If you need other features or have any feedback, please [submit an issue](https://console.apify.com/actors/3ox4R101TgZz67sLr/issues) in Apify Console to let us know.
 
+Are you interested in AI Agents and AI applications?
+Visit the [Model Context Protocol](https://modelcontextprotocol.org/) website and read blog post [What are AI agents?](https://blog.apify.com/what-are-ai-agents/).
+
 # 🚀 Roadmap (January 2025)
 
 - Document examples for [LibreChat](https://www.librechat.ai/).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/actors-mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "Model Context Protocol Server for Apify Actors",
   "engines": {

--- a/src/const.ts
+++ b/src/const.ts
@@ -3,6 +3,11 @@ export const SERVER_VERSION = '0.1.0';
 
 export const HEADER_READINESS_PROBE = 'x-apify-container-server-readiness-probe';
 
+export const MAX_ENUM_LENGTH = 50;
+export const MAX_DESCRIPTION_LENGTH = 200;
+
+export const USER_AGENT_ORIGIN = 'Origin/mcp-server';
+
 export const defaults = {
     actors: [
         'apify/instagram-scraper',

--- a/src/const.ts
+++ b/src/const.ts
@@ -5,6 +5,8 @@ export const HEADER_READINESS_PROBE = 'x-apify-container-server-readiness-probe'
 
 export const MAX_ENUM_LENGTH = 50;
 export const MAX_DESCRIPTION_LENGTH = 200;
+// Limit memory to 4GB for Actors. Free users have 8 GB limit, but we need to reserve some memory for Actors-MCP-Server too
+export const MAX_MEMORY_MBYTES = 4096;
 
 export const USER_AGENT_ORIGIN = 'Origin/mcp-server';
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -1,6 +1,8 @@
 export const SERVER_NAME = 'apify-mcp-server';
 export const SERVER_VERSION = '0.1.0';
 
+export const HEADER_READINESS_PROBE = 'x-apify-container-server-readiness-probe';
+
 export const defaults = {
     actors: [
         'apify/instagram-scraper',

--- a/src/examples/client_sse.py
+++ b/src/examples/client_sse.py
@@ -43,8 +43,9 @@ async def run() -> None:
                 print("No tools available!")
                 return
 
+            print("\n\nCall tool")
             result = await session.call_tool("apify/rag-web-browser", { "query": "example.com", "maxResults": 3 })
-            print("Tools Call Result:")
+            print("Tools call result:")
 
             for content in result.content:
                 print(content)

--- a/src/examples/client_sse.py
+++ b/src/examples/client_sse.py
@@ -34,6 +34,10 @@ async def run() -> None:
 
             tools = await session.list_tools()
             print("Available Tools:", tools, end="\n\n")
+            for tool in tools.tools:
+                print(f"\n### Tool name ###: {tool.name}")
+                print(f"\tdescription: {tool.description}")
+                print(f"\tinputSchema: {tool.inputSchema}")
 
             if hasattr(tools, "tools") and not tools.tools:
                 print("No tools available!")

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,10 +3,11 @@ import { parse } from 'querystring';
 
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { Actor } from 'apify';
+import type { ActorCallOptions } from 'apify-client';
 import type { Request, Response } from 'express';
 import express from 'express';
 
-import { HEADER_READINESS_PROBE, Routes } from './const.js';
+import { HEADER_READINESS_PROBE, MAX_MEMORY_MBYTES, Routes } from './const.js';
 import { processInput } from './input.js';
 import { log } from './logger.js';
 import { ApifyMcpServer } from './server.js';
@@ -115,6 +116,7 @@ if (STANDBY_MODE) {
     if (input && !input.debugActor && !input.debugActorInput) {
         await Actor.fail('If you need to debug a specific actor, please provide the debugActor and debugActorInput fields in the input');
     }
-    await mcpServer.callActorGetDataset(input.debugActor!, input.debugActorInput!);
+    const options = { memory: MAX_MEMORY_MBYTES } as ActorCallOptions;
+    await mcpServer.callActorGetDataset(input.debugActor!, input.debugActorInput!, options);
     await Actor.exit();
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { Actor } from 'apify';
 import type { Request, Response } from 'express';
 import express from 'express';
 
-import { Routes } from './const.js';
+import { HEADER_READINESS_PROBE, Routes } from './const.js';
 import { processInput } from './input.js';
 import { log } from './logger.js';
 import { ApifyMcpServer } from './server.js';
@@ -46,6 +46,11 @@ async function processParamsAndUpdateTools(url: string) {
 
 app.route(Routes.ROOT)
     .get(async (req: Request, res: Response) => {
+        if (req.headers && req.get(HEADER_READINESS_PROBE) !== undefined) {
+            log.debug('Received readiness probe');
+            res.status(200).json({ message: 'Server is ready' }).end();
+            return;
+        }
         try {
             log.info(`Received GET message at: ${req.url}`);
             await processParamsAndUpdateTools(req.url);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { ValidateFunction } from 'ajv';
-import type { ActorDefinition } from 'apify-client';
+import type { ActorDefaultRunOptions, ActorDefinition } from 'apify-client';
 
 export type Input = {
     actors: string[] | string;
@@ -9,6 +9,7 @@ export type Input = {
 
 export interface ActorDefinitionWithDesc extends ActorDefinition {
     description: string;
+    defaultRunOptions: ActorDefaultRunOptions
 }
 
 export interface Tool {
@@ -17,6 +18,7 @@ export interface Tool {
     description: string;
     inputSchema: object;
     ajvValidate: ValidateFunction;
+    memoryMbytes: number;
 }
 
 export interface SchemaProperties {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,3 +18,13 @@ export interface Tool {
     inputSchema: object;
     ajvValidate: ValidateFunction;
 }
+
+export interface SchemaProperties {
+    title: string;
+    description: string;
+    enum: string[]; // Array of string options for the enum
+    enumTitles: string[]; // Array of string titles for the enum
+    type: string; // Data type (e.g., "string")
+    default: string;
+    prefill: string;
+}


### PR DESCRIPTION
- Handle server readiness probe
- Add Origin/mcp-server to user-agent
- Truncate inputSchema description to 200 characters. Limit enums to 50 values.