### PR TITLE
feat: tool-items-type

### DIFF
--- a/src/actors.ts
+++ b/src/actors.ts
@@ -127,7 +127,7 @@ export function filterSchemaProperties(properties: { [key: string]: SchemaProper
             function getEditorItemType(editor: string): string | null {
                 const editorTypeMap: Record<string, string> = {
                     requestListSources: 'object',
-                    stringList: 'string'
+                    stringList: 'string',
                 };
                 return editorTypeMap[editor] || null;
             }

--- a/src/actors.ts
+++ b/src/actors.ts
@@ -111,6 +111,27 @@ export function filterSchemaProperties(properties: { [key: string]: SchemaProper
     for (const [key, property] of Object.entries(properties)) {
         const { title, description, enum: enumValues, type, default: defaultValue, prefill } = property;
         filteredProperties[key] = { title, description, enum: enumValues, type, default: defaultValue, prefill };
+        if (type === 'array') {
+            const itemsType: string | null = property.items?.type
+                || (property.prefill && typeof property.prefill)
+                || (property.default && typeof property.default)
+                || (property.editor && getEditorItemType(property.editor))
+                || null;
+
+            if (itemsType) {
+                filteredProperties[key].items = {
+                    type: itemsType,
+                };
+            }
+
+            function getEditorItemType(editor: string): string | null {
+                const editorTypeMap: Record<string, string> = {
+                    requestListSources: 'object',
+                    stringList: 'string'
+                };
+                return editorTypeMap[editor] || null;
+            }
+        }
     }
     return filteredProperties;
 }

--- a/src/actors.ts
+++ b/src/actors.ts
@@ -103,6 +103,26 @@ export function truncateActorReadme(readme: string, limit = ACTOR_README_MAX_LEN
     return `${readmeFirst}\n\nREADME was truncated because it was too long. Remaining headers:\n${prunedReadme.join(', ')}`;
 }
 /**
+ * Helps determine the type of items in an array schema property.
+ * Priority order: explicit type in items > prefill type > default value type > editor type.
+ */
+export function inferArrayItemType(property: SchemaProperties): string | null {
+    return property.items?.type
+        || (property.prefill && typeof property.prefill)
+        || (property.default && typeof property.default)
+        || (property.editor && getEditorItemType(property.editor))
+        || null;
+
+    function getEditorItemType(editor: string): string | null {
+        const editorTypeMap: Record<string, string> = {
+            requestListSources: 'object',
+            stringList: 'string',
+        };
+        return editorTypeMap[editor] || null;
+    }
+}
+
+/**
  * Filters schema properties to include only the necessary fields.
  * @param properties
  */
@@ -112,24 +132,9 @@ export function filterSchemaProperties(properties: { [key: string]: SchemaProper
         const { title, description, enum: enumValues, type, default: defaultValue, prefill } = property;
         filteredProperties[key] = { title, description, enum: enumValues, type, default: defaultValue, prefill };
         if (type === 'array') {
-            const itemsType: string | null = property.items?.type
-                || (property.prefill && typeof property.prefill)
-                || (property.default && typeof property.default)
-                || (property.editor && getEditorItemType(property.editor))
-                || null;
-
+            const itemsType = inferArrayItemType(property);
             if (itemsType) {
-                filteredProperties[key].items = {
-                    type: itemsType,
-                };
-            }
-
-            function getEditorItemType(editor: string): string | null {
-                const editorTypeMap: Record<string, string> = {
-                    requestListSources: 'object',
-                    stringList: 'string',
-                };
-                return editorTypeMap[editor] || null;
+                filteredProperties[key].items = { type: itemsType };
             }
         }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,8 @@ export interface SchemaProperties {
     type: string; // Data type (e.g., "string")
     default: string;
     prefill: string;
+    items?: { type: string; }
+    editor?: string;
 }
 
 //  ActorStoreList for actor-search tool

--- a/tests/actors-test.ts
+++ b/tests/actors-test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { actorNameToToolName } from '../src/actors.js';
+import { actorNameToToolName, inferArrayItemType } from '../src/actors.js';
 
 describe('actors', () => {
     describe('actorNameToToolName', () => {
@@ -25,6 +25,19 @@ describe('actors', () => {
             const longName = 'a'.repeat(70);
             const expected = 'a'.repeat(64);
             expect(actorNameToToolName(longName)).toBe(expected);
+        });
+
+        it('infers array item type from editor', () => {
+            const property = {
+                type: 'array',
+                editor: 'stringList',
+                title: '',
+                description: '',
+                enum: [],
+                default: '',
+                prefill: '',
+            };
+            expect(inferArrayItemType(property)).toBe('string');
         });
     });
 });


### PR DESCRIPTION
related to part of this issue https://github.com/apify/actors-mcp-server/issues/36


Updated `filterSchemaProperties` in `src/actors.ts` to handle array types by guessing `items.type` from `items.type`, `prefill`, `default`, or `editor`. Added `items` and `editor` to `SchemaProperties` in `src/types.ts`.
