### PR TITLE
fix: tool schema array type infer and nested props

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,7 @@ import apify from '@apify/eslint-config';
 
 // eslint-disable-next-line import/no-default-export
 export default [
-    { ignores: ['**/dist'] }, // Ignores need to happen first
+    { ignores: ['**/dist', '**/.venv'] }, // Ignores need to happen first
     ...apify,
     {
         languageOptions: {

--- a/src/actors.ts
+++ b/src/actors.ts
@@ -109,9 +109,9 @@ export function truncateActorReadme(readme: string, limit = ACTOR_README_MAX_LEN
 /**
  * Helps determine the type of items in an array schema property.
  * Priority order: explicit type in items > prefill type > default value type > editor type.
- * 
+ *
  * Based on JSON schema, the array needs a type, and most of the time Actor input schema does not have this, so we need to infer that.
- * 
+ *
  */
 export function inferArrayItemType(property: ISchemaProperties): string | null {
     return property.items?.type
@@ -133,13 +133,13 @@ export function inferArrayItemType(property: ISchemaProperties): string | null {
 
 /**
  * Add enum values as string to property descriptions.
- * 
+ *
  * This is done as a preventive measure to prevent cases where library or agent framework
  * does not handle enums or examples based on JSON schema definition.
- * 
+ *
  * https://json-schema.org/understanding-json-schema/reference/enum
  * https://json-schema.org/understanding-json-schema/reference/annotations
- * 
+ *
  * @param properties
  */
 function addEnumsToDescriptionsWithExamples(properties: Record<string, ISchemaProperties>): Record<string, ISchemaProperties> {
@@ -158,9 +158,9 @@ function addEnumsToDescriptionsWithExamples(properties: Record<string, ISchemaPr
 
 /**
  * Filters schema properties to include only the necessary fields.
- * 
+ *
  * This is done to reduce the size of the input schema and to make it more readable.
- * 
+ *
  * @param properties
  */
 export function filterSchemaProperties(properties: { [key: string]: ISchemaProperties }): { [key: string]: ISchemaProperties } {
@@ -195,7 +195,7 @@ export function filterSchemaProperties(properties: { [key: string]: ISchemaPrope
 /**
  * Marks input properties as required by adding a "REQUIRED" prefix to their descriptions.
  * Takes an IActorInput object and returns a modified Record of SchemaProperties.
- * 
+ *
  * This is done for maximum compatibility in case where library or agent framework does not consider
  * required fields and does not handle the JSON schema properly: we are prepending this to the description
  * as a preventive measure.
@@ -219,15 +219,15 @@ function markInputPropertiesAsRequired(input: IActorInputSchema): Record<string,
 
 /**
  * Builds nested properties for object types in the schema.
- * 
+ *
  * Specifically handles special cases like proxy configuration and request list sources
  * by adding predefined nested properties to these object types.
  * This is necessary for the agent to correctly infer how to structure object inputs
  * when passing arguments to the Actor.
- * 
+ *
  * For proxy objects (type='object', editor='proxy'), adds 'useApifyProxy' property.
  * For request list sources (type='array', editor='requestListSources'), adds URL structure to items.
- * 
+ *
  * @param {Record<string, ISchemaProperties>} properties - The input schema properties
  * @returns {Record<string, ISchemaProperties>} Modified properties with nested properties
  */
@@ -280,7 +280,7 @@ function buildNestedProperties(properties: Record<string, ISchemaProperties>): R
  * It uses the AJV library to validate the input schemas.
  *
  * Tool name can't contain /, so it is replaced with _
- * 
+ *
  * The input schema processing workflow:
  * 1. Properties are marked as required using markInputPropertiesAsRequired()
  * 2. Nested properties are built by analyzing editor type (proxy, requestListSources) using buildNestedProperties()

--- a/src/actors.ts
+++ b/src/actors.ts
@@ -142,10 +142,10 @@ export function inferArrayItemType(property: ISchemaProperties): string | null {
  * 
  * @param properties
  */
-function addEnumsToDescriptionsWithExamples(properties: { [key: string]: ISchemaProperties }): { [key: string]: ISchemaProperties } {
+function addEnumsToDescriptionsWithExamples(properties: Record<string, ISchemaProperties>): Record<string, ISchemaProperties> {
     for (const property of Object.values(properties)) {
         if (property.enum && property.enum.length > 0) {
-            property.description = `${property.description}\nPossible values: ${property.enum.join(',')}`;
+            property.description = `${property.description}\nPossible values: ${property.enum.slice(0, 20).join(',')}`;
         }
         const value = property.prefill ?? property.default;
         if (value && !(Array.isArray(value) && value.length === 0)) {
@@ -284,9 +284,9 @@ function buildNestedProperties(properties: Record<string, ISchemaProperties>): R
  * The input schema processing workflow:
  * 1. Properties are marked as required using markInputPropertiesAsRequired()
  * 2. Nested properties are built by analyzing editor type (proxy, requestListSources) using buildNestedProperties()
- * 3. Enums are added to descriptions with examples using addEnumsToDescriptionsWithExamples()
- * 4. Properties are filtered using filterSchemaProperties()
- * 5. Properties are shortened using shortenProperties()
+ * 3. Properties are filtered using filterSchemaProperties()
+ * 4. Properties are shortened using shortenProperties()
+ * 5. Enums are added to descriptions with examples using addEnumsToDescriptionsWithExamples()
  *
  * @param {string[]} actors - An array of actor IDs or Actor full names.
  * @returns {Promise<Tool[]>} - A promise that resolves to an array of MCP tools.
@@ -300,9 +300,9 @@ export async function getActorsAsTools(actors: string[]): Promise<Tool[]> {
             if (result.input && 'properties' in result.input && result.input) {
                 const propertiesMarkedAsRequired = markInputPropertiesAsRequired(result.input);
                 const propertiesObjectsBuilt = buildNestedProperties(propertiesMarkedAsRequired);
-                const propertiesWithExamples = addEnumsToDescriptionsWithExamples(propertiesObjectsBuilt);
-                const propertiesFiltered = filterSchemaProperties(propertiesWithExamples);
-                result.input.properties = shortenProperties(propertiesFiltered);
+                const propertiesFiltered = filterSchemaProperties(propertiesObjectsBuilt);
+                const propertiesShortened = shortenProperties(propertiesFiltered);
+                result.input.properties = addEnumsToDescriptionsWithExamples(propertiesShortened);
             }
             try {
                 const memoryMbytes = result.defaultRunOptions?.memoryMbytes || defaults.maxMemoryMbytes;

--- a/src/actors.ts
+++ b/src/actors.ts
@@ -108,8 +108,8 @@ export function truncateActorReadme(readme: string, limit = ACTOR_README_MAX_LEN
  */
 export function inferArrayItemType(property: SchemaProperties): string | null {
     return property.items?.type
-        || (property.prefill && typeof property.prefill[0])
-        || (property.default && typeof property.default[0])
+        || (property.prefill?.length > 0 && typeof property.prefill[0])
+        || (property.default?.length > 0 && typeof property.default[0])
         || (property.editor && getEditorItemType(property.editor))
         || null;
 
@@ -117,6 +117,8 @@ export function inferArrayItemType(property: SchemaProperties): string | null {
         const editorTypeMap: Record<string, string> = {
             requestListSources: 'object',
             stringList: 'string',
+            json: 'object',
+            globs: 'object',
         };
         return editorTypeMap[editor] || null;
     }
@@ -134,6 +136,7 @@ export function addEnumsToDescriptionsWithExamples(properties: { [key: string]: 
         const value = property.prefill ?? property.default;
         if (value && !(Array.isArray(value) && value.length === 0)) {
             property.examples = Array.isArray(value) ? value : [value];
+            property.description = `${property.description}\nExample values: ${JSON.stringify(value)}`;
         }
     }
     return properties;

--- a/src/actors.ts
+++ b/src/actors.ts
@@ -110,7 +110,7 @@ export function truncateActorReadme(readme: string, limit = ACTOR_README_MAX_LEN
  * Helps determine the type of items in an array schema property.
  * Priority order: explicit type in items > prefill type > default value type > editor type.
  */
-function inferArrayItemType(property: ISchemaProperties): string | null {
+export function inferArrayItemType(property: ISchemaProperties): string | null {
     return property.items?.type
         || (Array.isArray(property.prefill) && property.prefill.length > 0 && typeof property.prefill[0])
         || (Array.isArray(property.default) && property.default.length > 0 && typeof property.default[0])
@@ -241,7 +241,6 @@ function buildNestedProperties(properties: Record<string, ISchemaProperties>): R
                         },
                     },
                 },
-                required: ['useApifyProxy'],
             };
         }
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,7 +34,7 @@ import {
     searchActorsByKeywords,
     GetActorDefinition,
 } from './tools.js';
-import type { SchemaProperties, Tool } from './types.js';
+import type { ISchemaProperties, Tool } from './types.js';
 
 /**
  * Create Apify MCP server
@@ -199,7 +199,7 @@ export class ApifyMcpServer {
                         const parsed = GetActorDefinition.parse(args);
                         const v = await getActorDefinition(parsed.actorName, parsed.limit);
                         if (v && v.input && 'properties' in v.input && v.input) {
-                            const properties = filterSchemaProperties(v.input.properties as { [key: string]: SchemaProperties });
+                            const properties = filterSchemaProperties(v.input.properties as { [key: string]: ISchemaProperties });
                             v.input.properties = shortenProperties(properties);
                         }
                         return { content: [{ type: 'text', text: JSON.stringify(v) }] };

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,22 +9,47 @@ export type Input = {
     debugActorInput?: unknown;
 };
 
-export interface ActorDefinitionPruned {
-    id: string;
-    actorFullName: string;
-    buildTag?: string;
-    readme?: string | null;
-    input?: object | null;
+export interface ISchemaProperties {
+    type: string;
+
+    title: string;
     description: string;
-    defaultRunOptions: ActorDefaultRunOptions;
+
+    enum?: string[]; // Array of string options for the enum
+    enumTitles?: string[]; // Array of string titles for the enum
+    default?: unknown;
+    prefill?: unknown;
+
+    items?: ISchemaProperties;
+    editor?: string;
+    examples?: unknown[];
+
+    properties?: Record<string, ISchemaProperties>;
+    required?: string[];
 }
 
-export interface ActorDefinitionWithDesc extends ActorDefinition {
+export interface IActorInputSchema {
+    title?: string;
+    description?: string;
+
+    type: string;
+
+    properties: Record<string, ISchemaProperties>;
+
+    required?: string[];
+    schemaVersion?: number;
+}
+
+export type ActorDefinitionWithDesc = Omit<ActorDefinition, 'input'> & {
     id: string;
     actorFullName: string;
     description: string;
-    defaultRunOptions: ActorDefaultRunOptions
+    defaultRunOptions: ActorDefaultRunOptions;
+    input?: IActorInputSchema;
 }
+
+export type ActorDefinitionPruned = Pick<ActorDefinitionWithDesc,
+    'id' | 'actorFullName' | 'buildTag' | 'readme' | 'input' | 'description' | 'defaultRunOptions'>
 
 export interface Tool {
     name: string;
@@ -33,19 +58,6 @@ export interface Tool {
     inputSchema: object;
     ajvValidate: ValidateFunction;
     memoryMbytes?: number;
-}
-
-export interface SchemaProperties {
-    title: string;
-    description: string;
-    enum: string[]; // Array of string options for the enum
-    enumTitles?: string[]; // Array of string titles for the enum
-    type: string; // Data type (e.g., "string")
-    default: string;
-    prefill: string;
-    items?: { type: string; }
-    editor?: string;
-    examples?: unknown[];
 }
 
 //  ActorStoreList for actor-search tool


### PR DESCRIPTION
mastra.ai agent failed to run WCC because of the nested properties, the object input properties: had to infer their schema based on the editor provided; This helps the agent to call the WCC with the correct options.