### PR TITLE
fix: ajv compile memory leak

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -8,6 +8,10 @@ export function actorNameToToolName(actorName: string): string {
         .slice(0, 64);
 }
 
+export function getToolSchemaID(actorName: string): string {
+    return `https://apify.com/mcp/${actorNameToToolName(actorName)}/schema.json`;
+}
+
 /**
  * Builds nested properties for object types in the schema.
  *

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export interface ISchemaProperties {
 }
 
 export interface IActorInputSchema {
-    $id: string;
+    $id?: string;
     title?: string;
     description?: string;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface ISchemaProperties {
 }
 
 export interface IActorInputSchema {
+    $id: string;
     title?: string;
     description?: string;
 


### PR DESCRIPTION
this should fix the Ajv memory leak, tested locally with MCP stress tester swarm mode - the memory stays consistently around 170 MB

closes https://github.com/apify/apify-mcp-server/issues/56