### PR TITLE
fix: notifications

### DIFF
--- a/src/actor/server.ts
+++ b/src/actor/server.ts
@@ -130,7 +130,7 @@ export function createExpressApp(
             // New initialization request - use JSON response mode
                 transport = new StreamableHTTPServerTransport({
                     sessionIdGenerator: () => randomUUID(),
-                    enableJsonResponse: true, // Enable JSON response mode
+                    enableJsonResponse: false, // Use SSE response mode
                 });
                 // Load MCP server tools
                 await loadToolsAndActors(mcpServer, req.url, process.env.APIFY_TOKEN as string);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -344,7 +344,7 @@ export class ActorsMcpServer {
          * @param {object} request - The request object containing tool name and arguments.
          * @throws {McpError} - based on the McpServer class code from the typescript MCP SDK
          */
-        this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+        this.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
             // eslint-disable-next-line prefer-const
             let { name, arguments: args } = request.params;
             const apifyToken = (request.params.apifyToken || process.env.APIFY_TOKEN) as string;
@@ -412,6 +412,7 @@ export class ActorsMcpServer {
                     const internalTool = tool.tool as HelperTool;
                     const res = await internalTool.call({
                         args,
+                        extra,
                         apifyMcpServer: this,
                         mcpServer: this.server,
                         apifyToken,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -342,6 +342,7 @@ export class ActorsMcpServer {
         /**
          * Handles the request to call a tool.
          * @param {object} request - The request object containing tool name and arguments.
+         * @param {object} extra - Extra data given to the request handler, such as sendNotification function.
          * @throws {McpError} - based on the McpServer class code from the typescript MCP SDK
          */
         this.server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -78,7 +78,7 @@ export const addTool: ToolEntry = {
         ajvValidate: ajv.compile(zodToJsonSchema(addToolArgsSchema)),
         // TODO: I don't like that we are passing apifyMcpServer and mcpServer to the tool
         call: async (toolArgs) => {
-            const { apifyMcpServer, mcpServer, apifyToken, args } = toolArgs;
+            const { apifyMcpServer, apifyToken, args, extra } = toolArgs;
             const parsed = addToolArgsSchema.parse(args);
             if (apifyMcpServer.listAllToolNames().includes(parsed.actorName)) {
                 return {
@@ -90,7 +90,7 @@ export const addTool: ToolEntry = {
             }
             const tools = await getActorsAsTools([parsed.actorName], apifyToken);
             const toolsAdded = apifyMcpServer.upsertTools(tools, true);
-            await mcpServer.notification({ method: 'notifications/tools/list_changed' });
+            await extra.sendNotification({ method: 'notifications/tools/list_changed' });
 
             return {
                 content: [{
@@ -121,13 +121,13 @@ export const removeTool: ToolEntry = {
         ajvValidate: ajv.compile(zodToJsonSchema(removeToolArgsSchema)),
         // TODO: I don't like that we are passing apifyMcpServer and mcpServer to the tool
         call: async (toolArgs) => {
-            const { apifyMcpServer, mcpServer, args } = toolArgs;
+            const { apifyMcpServer, args, extra } = toolArgs;
             const parsed = removeToolArgsSchema.parse(args);
             // Check if tool exists before attempting removal
             if (!apifyMcpServer.tools.has(parsed.toolName)) {
                 // Send notification so client can update its tool list
                 // just in case the client tool list is out of sync
-                await mcpServer.notification({ method: 'notifications/tools/list_changed' });
+                await extra.sendNotification({ method: 'notifications/tools/list_changed' });
                 return {
                     content: [{
                         type: 'text',
@@ -136,7 +136,7 @@ export const removeTool: ToolEntry = {
                 };
             }
             const removedTools = apifyMcpServer.removeToolsByName([parsed.toolName], true);
-            await mcpServer.notification({ method: 'notifications/tools/list_changed' });
+            await extra.sendNotification({ method: 'notifications/tools/list_changed' });
             return { content: [{ type: 'text', text: `Tools removed: ${removedTools.join(', ')}` }] };
         },
     } as InternalTool,

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -78,7 +78,7 @@ export const addTool: ToolEntry = {
         ajvValidate: ajv.compile(zodToJsonSchema(addToolArgsSchema)),
         // TODO: I don't like that we are passing apifyMcpServer and mcpServer to the tool
         call: async (toolArgs) => {
-            const { apifyMcpServer, apifyToken, args, extra } = toolArgs;
+            const { apifyMcpServer, apifyToken, args, extra: { sendNotification } } = toolArgs;
             const parsed = addToolArgsSchema.parse(args);
             if (apifyMcpServer.listAllToolNames().includes(parsed.actorName)) {
                 return {
@@ -90,7 +90,7 @@ export const addTool: ToolEntry = {
             }
             const tools = await getActorsAsTools([parsed.actorName], apifyToken);
             const toolsAdded = apifyMcpServer.upsertTools(tools, true);
-            await extra.sendNotification({ method: 'notifications/tools/list_changed' });
+            await sendNotification({ method: 'notifications/tools/list_changed' });
 
             return {
                 content: [{
@@ -121,13 +121,13 @@ export const removeTool: ToolEntry = {
         ajvValidate: ajv.compile(zodToJsonSchema(removeToolArgsSchema)),
         // TODO: I don't like that we are passing apifyMcpServer and mcpServer to the tool
         call: async (toolArgs) => {
-            const { apifyMcpServer, args, extra } = toolArgs;
+            const { apifyMcpServer, args, extra: { sendNotification } } = toolArgs;
             const parsed = removeToolArgsSchema.parse(args);
             // Check if tool exists before attempting removal
             if (!apifyMcpServer.tools.has(parsed.toolName)) {
                 // Send notification so client can update its tool list
                 // just in case the client tool list is out of sync
-                await extra.sendNotification({ method: 'notifications/tools/list_changed' });
+                await sendNotification({ method: 'notifications/tools/list_changed' });
                 return {
                     content: [{
                         type: 'text',
@@ -136,7 +136,7 @@ export const removeTool: ToolEntry = {
                 };
             }
             const removedTools = apifyMcpServer.removeToolsByName([parsed.toolName], true);
-            await extra.sendNotification({ method: 'notifications/tools/list_changed' });
+            await sendNotification({ method: 'notifications/tools/list_changed' });
             return { content: [{ type: 'text', text: `Tools removed: ${removedTools.join(', ')}` }] };
         },
     } as InternalTool,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,6 @@
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import type { Notification, Request } from '@modelcontextprotocol/sdk/types.js';
 import type { ValidateFunction } from 'ajv';
 import type { ActorDefaultRunOptions, ActorDefinition } from 'apify-client';
 
@@ -80,6 +82,10 @@ export interface ActorTool extends ToolBase {
 export type InternalToolArgs = {
     /** Arguments passed to the tool */
     args: Record<string, unknown>;
+    /** MCP server extra args.
+     * Can be used to send notifications from the server to the client.
+     */
+    extra: RequestHandlerExtra<Request, Notification>;
     /** Reference to the Apify MCP server instance */
     apifyMcpServer: ActorsMcpServer;
     /** Reference to the MCP server instance */

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,8 +82,11 @@ export interface ActorTool extends ToolBase {
 export type InternalToolArgs = {
     /** Arguments passed to the tool */
     args: Record<string, unknown>;
-    /** MCP server extra args.
+    /** Extra data given to request handlers.
+     *
      * Can be used to send notifications from the server to the client.
+     *
+     * For more details see: https://github.com/modelcontextprotocol/typescript-sdk/blob/f822c1255edcf98c4e73b9bf17a9dd1b03f86716/src/shared/protocol.ts#L102
      */
     extra: RequestHandlerExtra<Request, Notification>;
     /** Reference to the Apify MCP server instance */

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -1,4 +1,5 @@
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { ToolListChangedNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import { defaults, HelperTools } from '../../src/const.js';
@@ -327,6 +328,25 @@ export function createIntegrationTestsSuite(
 
             // Check if the notification was NOT received
             expect(notificationCount).toBe(1);
+            await client.close();
+        });
+
+        it('should notify client about tool list changed', async () => {
+            const client = await createClientFn({ enableAddingActors: true });
+
+            // This flag is set to true when a 'notifications/tools/list_changed' notification is received,
+            // indicating that the tool list has been updated dynamically.
+            let hasReceivedNotification = false;
+            client.setNotificationHandler(ToolListChangedNotificationSchema, async (notification) => {
+                if (notification.method === 'notifications/tools/list_changed') {
+                    hasReceivedNotification = true;
+                }
+            });
+            // Add Actor dynamically
+            await client.callTool({ name: HelperTools.ACTOR_ADD, arguments: { actorName: ACTOR_PYTHON_EXAMPLE } });
+
+            expect(hasReceivedNotification).toBe(true);
+
             await client.close();
         });
     });


### PR DESCRIPTION
Use MCP request handler extras for notification sending - this is needed so streamable POST SSE notifications work correctly. Also fixes notifications in streamable transport for the standby Actor mode which were not working - this needs POST SSE but it should be safe because the SSE sessions are usually short-lived until all tool call or other requests are finished and then new is created for each POST request.

prerequisite to https://github.com/apify/apify-mcp-server/pull/69
related to https://github.com/apify/apify-mcp-server/issues/64