### PR TITLE
feat: call-actor tool

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -17,6 +17,7 @@ export const USER_AGENT_ORIGIN = 'Origin/mcp-server';
 
 export enum HelperTools {
     ACTOR_ADD = 'add-actor',
+    ACTOR_CALL = 'call-actor',
     ACTOR_GET = 'get-actor',
     ACTOR_GET_DETAILS = 'get-actor-details',
     ACTOR_REMOVE = 'remove-actor',

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -130,7 +130,7 @@ export class ActorsMcpServer {
      * Returns the list of all currently loaded Actor tool IDs.
      * @returns {string[]} - Array of loaded Actor tool IDs (e.g., 'apify/rag-web-browser')
      */
-    private listActorToolNames(): string[] {
+    public listActorToolNames(): string[] {
         return Array.from(this.tools.values())
             .filter((tool) => tool.type === 'actor')
             .map((tool) => (tool.tool as ActorTool).actorFullName);

--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -307,7 +307,7 @@ export const callActor: ToolEntry = {
     tool: {
         name: HelperTools.ACTOR_CALL,
         actorFullName: HelperTools.ACTOR_CALL,
-        description: 'Call Actor and get dataset id. Call without input and result response with requred input properties.',
+        description: `Call Actor and get dataset results. Call without input and result response with requred input properties. Actor MUST be added before calling, use ${HelperTools.ACTOR_ADD} tool before.`,
         inputSchema: zodToJsonSchema(callActorArgs),
         ajvValidate: ajv.compile(zodToJsonSchema(callActorArgs)),
         call: async (toolArgs) => {

--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -316,7 +316,7 @@ export const callActor: ToolEntry = {
 
             const actors = apifyMcpServer.listActorToolNames();
             if (!actors.includes(actorName)) {
-                const toolsText = actors.length > 0 ? `Added Actors are: ${actors.join(', ')}` : 'Not added Actors yet.';
+                const toolsText = actors.length > 0 ? `Available Actors are: ${actors.join(', ')}` : 'Not added Actors yet.';
                 if (apifyMcpServer.tools.has(HelperTools.ACTOR_ADD)) {
                     return {
                         content: [{
@@ -328,7 +328,12 @@ export const callActor: ToolEntry = {
                 return {
                     content: [{
                         type: 'text',
-                        text: `Actor '${actorName}' is not added. ${toolsText}`,
+                        text: `Actor '${actorName}' is not added. ${toolsText}
+To use this MCP server, specify the actors with the parameter, for example:
+?actors=apify/instagram-scraper,apify/website-content-crawler
+or with the CLI:
+--actors "apify/instagram-scraper,apify/website-content-crawler"
+You can only use actors that are included in the list; actors not in the list cannot be used.`,
                     }],
                 };
             }
@@ -370,7 +375,7 @@ export const callActor: ToolEntry = {
                     })),
                 };
             } catch (error) {
-                console.error(`Error calling Actor: ${error}`);
+                log.error(`Error calling Actor: ${error}`);
                 return {
                     content: [
                         { type: 'text', text: `Error calling Actor: ${error instanceof Error ? error.message : String(error)}` },

--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -291,7 +291,7 @@ export const getActor: ToolEntry = {
 };
 
 const callActorArgs = z.object({
-    actorName: z.string()
+    actor: z.string()
         .describe('The name of the Actor to call.'),
     input: z.object({}).passthrough()
         .describe('The input JSON to pass to the Actor.'),
@@ -312,7 +312,7 @@ export const callActor: ToolEntry = {
         ajvValidate: ajv.compile(zodToJsonSchema(callActorArgs)),
         call: async (toolArgs) => {
             const { apifyMcpServer, args, apifyToken } = toolArgs;
-            const { actorName, input, callOptions } = callActorArgs.parse(args);
+            const { actor: actorName, input, callOptions } = callActorArgs.parse(args);
 
             const actors = apifyMcpServer.listActorToolNames();
             if (!actors.includes(actorName)) {

--- a/src/tools/actor.ts
+++ b/src/tools/actor.ts
@@ -265,8 +265,8 @@ export const getActor: ToolEntry = {
 const callActorArgs = z.object({
     actorName: z.string()
         .describe('The name of the Actor to call.'),
-    input: z.any()
-        .describe('The input to pass to the Actor.'),
+    input: z.object({}).passthrough()
+        .describe('The input JSON to pass to the Actor.'),
     callOptions: z.object({
         memory: z.number().optional(),
         timeout: z.number().optional(),

--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -39,7 +39,14 @@ export const addTool: ToolEntry = {
     type: 'internal',
     tool: {
         name: HelperTools.ACTOR_ADD,
-        description: `Add an Actor or MCP server to the available tools of the Apify MCP server. A tool is an Actor or MCP server that can be called by the user. Do not execute the tool, only add it and list it in the available tools. For example, when a user wants to scrape a website, first search for relevant Actors using ${HelperTools.STORE_SEARCH} tool, and once the user selects one they want to use, add it as a tool to the Apify MCP server.`,
+        description:
+            `Add an Actor or MCP server to the available tools of the Apify MCP server. 
+A tool is an Actor or MCP server that can be called by the user. 
+Do not execute the tool, only add it and list it in the available tools. 
+For example, when a user wants to scrape a website, first search for relevant Actors
+using ${HelperTools.STORE_SEARCH} tool, and once the user selects one they want to use, 
+add it as a tool to the Apify MCP server.
+If added tools is not available, use generic tool ${HelperTools.ACTOR_CALL} to call added Actor directly.`,
         inputSchema: zodToJsonSchema(addToolArgsSchema),
         ajvValidate: ajv.compile(zodToJsonSchema(addToolArgsSchema)),
         // TODO: I don't like that we are passing apifyMcpServer and mcpServer to the tool

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,5 +1,5 @@
 // Import specific tools that are being used
-import { callActorGetDataset, getActor, getActorsAsTools } from './actor.js';
+import { callActor, callActorGetDataset, getActor, getActorsAsTools } from './actor.js';
 import { actorDefinitionTool } from './build.js';
 import { getDataset, getDatasetItems } from './dataset.js';
 import { getUserDatasetsList } from './dataset_collection.js';
@@ -13,6 +13,7 @@ import { searchActors } from './store_collection.js';
 export const defaultTools = [
     abortActorRun,
     actorDefinitionTool,
+    callActor,
     getActor,
     getActorLog,
     getActorRun,


### PR DESCRIPTION
closes #155

Generic tool for calling Actors dynamically, for clients without support for the dynamic tools list.

TODO:
- [x] allow call only added tools
- [x] add to add-tools description info, "'call-actor' can be used when the added tool is not found"
- [x] add to this tool info "use 'add-actor' before this tool"
- [x] merge branch feat/fewer-tools--improve-tool-output and setup as target