### PR TITLE
feat: add tool selection by feature param

### DIFF
--- a/src/actor/server.ts
+++ b/src/actor/server.ts
@@ -13,25 +13,8 @@ import log from '@apify/log';
 
 import { ActorsMcpServer } from '../mcp/server.js';
 import { parseInputParamsFromUrl } from '../mcp/utils.js';
-import { getActorsAsTools } from '../tools/actor.js';
 import { getHelpMessage, HEADER_READINESS_PROBE, Routes } from './const.js';
 import { getActorRunData } from './utils.js';
-
-/**
- * Helper function to load tools and actors based on input parameters
- * @param mcpServer The MCP server instance
- * @param url The request URL to parse parameters from
- * @param apifyToken The Apify token for authentication
- */
-async function loadToolsAndActors(mcpServer: ActorsMcpServer, url: string, apifyToken: string): Promise<void> {
-    const input = parseInputParamsFromUrl(url);
-    if (input.actors || input.enableAddingActors) {
-        await mcpServer.loadToolsFromUrl(url, apifyToken);
-    }
-    if (!input.actors) {
-        await mcpServer.loadDefaultActors(apifyToken);
-    }
-}
 
 export function createExpressApp(
     host: string,
@@ -85,13 +68,21 @@ export function createExpressApp(
         try {
             log.info(`Received GET message at: ${Routes.SSE}`);
             const mcpServer = new ActorsMcpServer(mcpServerOptions, false);
-            // Load tools from Actor input for backwards compatibility
-            if (mcpServerOptions.actors && mcpServerOptions.actors.length > 0) {
-                const tools = await getActorsAsTools(mcpServerOptions.actors, process.env.APIFY_TOKEN as string);
-                mcpServer.upsertTools(tools);
-            }
-            await loadToolsAndActors(mcpServer, req.url, process.env.APIFY_TOKEN as string);
             const transport = new SSEServerTransport(Routes.MESSAGE, res);
+
+            // Load MCP server tools
+            const apifyToken = process.env.APIFY_TOKEN as string;
+            const input = parseInputParamsFromUrl(req.url);
+            if (input.actors || input.enableAddingActors || input.beta || input.tools) {
+                log.debug('[SSE] Loading tools from URL', { sessionId: transport.sessionId });
+                await mcpServer.loadToolsFromUrl(req.url, apifyToken);
+            }
+            // Load default tools if no actors are specified
+            if (!input.actors) {
+                log.debug('[SSE] Loading default tools', { sessionId: transport.sessionId });
+                await mcpServer.loadDefaultActors(apifyToken);
+            }
+
             transportsSSE[transport.sessionId] = transport;
             mcpServers[transport.sessionId] = mcpServer;
             await mcpServer.connect(transport);
@@ -164,13 +155,20 @@ export function createExpressApp(
                     enableJsonResponse: false, // Use SSE response mode
                 });
                 const mcpServer = new ActorsMcpServer(mcpServerOptions, false);
-                // Load tools from Actor input for backwards compatibility
-                if (mcpServerOptions.actors && mcpServerOptions.actors.length > 0) {
-                    const tools = await getActorsAsTools(mcpServerOptions.actors, process.env.APIFY_TOKEN as string);
-                    mcpServer.upsertTools(tools);
-                }
+
                 // Load MCP server tools
-                await loadToolsAndActors(mcpServer, req.url, process.env.APIFY_TOKEN as string);
+                const apifyToken = process.env.APIFY_TOKEN as string;
+                const input = parseInputParamsFromUrl(req.url);
+                if (input.actors || input.enableAddingActors || input.beta || input.tools) {
+                    log.debug('[Streamable] Loading tools from URL', { sessionId: transport.sessionId });
+                    await mcpServer.loadToolsFromUrl(req.url, apifyToken);
+                }
+                // Load default tools if no actors are specified
+                if (!input.actors) {
+                    log.debug('[Streamable] Loading default tools', { sessionId: transport.sessionId });
+                    await mcpServer.loadDefaultActors(apifyToken);
+                }
+
                 // Connect the transport to the MCP server BEFORE handling the request
                 await mcpServer.connect(transport);
 

--- a/src/actor/server.ts
+++ b/src/actor/server.ts
@@ -73,7 +73,7 @@ export function createExpressApp(
             // Load MCP server tools
             const apifyToken = process.env.APIFY_TOKEN as string;
             const input = parseInputParamsFromUrl(req.url);
-            if (input.actors || input.enableAddingActors || input.beta || input.tools) {
+            if (input.actors || input.enableAddingActors || input.tools) {
                 log.debug('[SSE] Loading tools from URL', { sessionId: transport.sessionId });
                 await mcpServer.loadToolsFromUrl(req.url, apifyToken);
             }
@@ -159,7 +159,7 @@ export function createExpressApp(
                 // Load MCP server tools
                 const apifyToken = process.env.APIFY_TOKEN as string;
                 const input = parseInputParamsFromUrl(req.url);
-                if (input.actors || input.enableAddingActors || input.beta || input.tools) {
+                if (input.actors || input.enableAddingActors || input.tools) {
                     log.debug('[Streamable] Loading tools from URL', { sessionId: transport.sessionId });
                     await mcpServer.loadToolsFromUrl(req.url, apifyToken);
                 }

--- a/src/input.ts
+++ b/src/input.ts
@@ -3,7 +3,7 @@
  */
 import log from '@apify/log';
 
-import type { Input } from './types.js';
+import type { FeatureToolKey, Input } from './types.js';
 
 /**
  * Process input parameters, split Actors string into an array
@@ -32,5 +32,9 @@ export function processInput(originalInput: Partial<Input>): Input {
 
     // If beta present, set input.beta to true
     input.beta = input.beta !== undefined && (input.beta !== false && input.beta !== 'false');
+
+    if (input.tools && typeof input.tools === 'string') {
+        input.tools = input.tools.split(',').map((tool: string) => tool.trim()) as FeatureToolKey[];
+    }
     return input;
 }

--- a/src/input.ts
+++ b/src/input.ts
@@ -3,7 +3,7 @@
  */
 import log from '@apify/log';
 
-import type { FeatureToolKey, Input } from './types.js';
+import type { Input, ToolCategory } from './types.js';
 
 /**
  * Process input parameters, split Actors string into an array
@@ -30,11 +30,8 @@ export function processInput(originalInput: Partial<Input>): Input {
         input.enableAddingActors = input.enableAddingActors === true || input.enableAddingActors === 'true';
     }
 
-    // If beta present, set input.beta to true
-    input.beta = input.beta !== undefined && (input.beta !== false && input.beta !== 'false');
-
     if (input.tools && typeof input.tools === 'string') {
-        input.tools = input.tools.split(',').map((tool: string) => tool.trim()) as FeatureToolKey[];
+        input.tools = input.tools.split(',').map((tool: string) => tool.trim()) as ToolCategory[];
     }
     return input;
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -23,9 +23,9 @@ import {
     SERVER_NAME,
     SERVER_VERSION,
 } from '../const.js';
-import { addRemoveTools, betaTools, callActorGetDataset, defaultTools, getActorsAsTools } from '../tools/index.js';
+import { addRemoveTools, betaTools, callActorGetDataset, defaultTools, featureTools, getActorsAsTools } from '../tools/index.js';
 import { actorNameToToolName, decodeDotPropertyNames } from '../tools/utils.js';
-import type { ActorMcpTool, ActorTool, HelperTool, ToolEntry } from '../types.js';
+import type { ActorMcpTool, ActorTool, FeatureToolKey, HelperTool, ToolEntry } from '../types.js';
 import { connectMCPClient } from './client.js';
 import { EXTERNAL_TOOL_CALL_TIMEOUT_MSEC } from './const.js';
 import { processParamsGetTools } from './utils.js';
@@ -173,6 +173,13 @@ export class ActorsMcpServer {
         const actorsToLoad: string[] = [];
         const toolsToLoad: ToolEntry[] = [];
         const internalToolMap = new Map([...defaultTools, ...addRemoveTools, ...betaTools].map((tool) => [tool.tool.name, tool]));
+        // Add all feature tools
+        for (const key of Object.keys(featureTools)) {
+            const tools = featureTools[key as FeatureToolKey];
+            for (const tool of tools) {
+                internalToolMap.set(tool.tool.name, tool);
+            }
+        }
 
         for (const tool of toolNames) {
             // Skip if the tool is already loaded

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -25,7 +25,7 @@ import {
 } from '../const.js';
 import { addRemoveTools, callActorGetDataset, defaultTools, getActorsAsTools, toolCategories } from '../tools/index.js';
 import { actorNameToToolName, decodeDotPropertyNames } from '../tools/utils.js';
-import type { ActorMcpTool, ActorTool, HelperTool, ToolCategory, ToolEntry } from '../types.js';
+import type { ActorMcpTool, ActorTool, HelperTool, ToolEntry } from '../types.js';
 import { connectMCPClient } from './client.js';
 import { EXTERNAL_TOOL_CALL_TIMEOUT_MSEC } from './const.js';
 import { processParamsGetTools } from './utils.js';
@@ -166,14 +166,11 @@ export class ActorsMcpServer {
         const loadedTools = this.listAllToolNames();
         const actorsToLoad: string[] = [];
         const toolsToLoad: ToolEntry[] = [];
-        const internalToolMap = new Map([...defaultTools, ...addRemoveTools].map((tool) => [tool.tool.name, tool]));
-        // Add all category tools
-        for (const key of Object.keys(toolCategories)) {
-            const tools = toolCategories[key as ToolCategory];
-            for (const tool of tools) {
-                internalToolMap.set(tool.tool.name, tool);
-            }
-        }
+        const internalToolMap = new Map([
+            ...defaultTools,
+            ...addRemoveTools,
+            ...Object.values(toolCategories).flat(),
+        ].map((tool) => [tool.tool.name, tool]));
 
         for (const tool of toolNames) {
             // Skip if the tool is already loaded

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -2,8 +2,8 @@ import { createHash } from 'node:crypto';
 import { parse } from 'node:querystring';
 
 import { processInput } from '../input.js';
-import { addRemoveTools, betaTools, getActorsAsTools } from '../tools/index.js';
-import type { Input, ToolEntry } from '../types.js';
+import { addRemoveTools, betaTools, featureTools, getActorsAsTools } from '../tools/index.js';
+import type { FeatureToolKey, Input, ToolEntry } from '../types.js';
 import { MAX_TOOL_NAME_LENGTH, SERVER_ID_LENGTH } from './const.js';
 
 /**
@@ -52,6 +52,14 @@ export async function processParamsGetTools(url: string, apifyToken: string) {
     }
     if (input.beta) {
         tools.push(...betaTools);
+    }
+    if (input.tools) {
+        for (const toolKey of input.tools) {
+            // Get tools by feature key
+            const keyTools = featureTools[toolKey as FeatureToolKey] || [];
+            // Push them into the tools array
+            tools.push(...keyTools);
+        }
     }
     return tools;
 }

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -2,8 +2,8 @@ import { createHash } from 'node:crypto';
 import { parse } from 'node:querystring';
 
 import { processInput } from '../input.js';
-import { addRemoveTools, betaTools, featureTools, getActorsAsTools } from '../tools/index.js';
-import type { FeatureToolKey, Input, ToolEntry } from '../types.js';
+import type { Input } from '../types.js';
+import { loadToolsFromInput } from '../utils/tools-loader.js';
 import { MAX_TOOL_NAME_LENGTH, SERVER_ID_LENGTH } from './const.js';
 
 /**
@@ -34,34 +34,14 @@ export function getProxyMCPServerToolName(url: string, toolName: string): string
 }
 
 /**
- * Process input parameters and get tools
+ * Process input parameters from URL and get tools
  * If URL contains query parameter `actors`, return tools from Actors otherwise return null.
  * @param url
  * @param apifyToken
  */
 export async function processParamsGetTools(url: string, apifyToken: string) {
     const input = parseInputParamsFromUrl(url);
-    let tools: ToolEntry[] = [];
-    if (input.actors) {
-        const actors = input.actors as string[];
-        // Normal Actors as a tool
-        tools = await getActorsAsTools(actors, apifyToken);
-    }
-    if (input.enableAddingActors) {
-        tools.push(...addRemoveTools);
-    }
-    if (input.beta) {
-        tools.push(...betaTools);
-    }
-    if (input.tools) {
-        for (const toolKey of input.tools) {
-            // Get tools by feature key
-            const keyTools = featureTools[toolKey as FeatureToolKey] || [];
-            // Push them into the tools array
-            tools.push(...keyTools);
-        }
-    }
-    return tools;
+    return await loadToolsFromInput(input, apifyToken);
 }
 
 export function parseInputParamsFromUrl(url: string): Input {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,31 +1,42 @@
 // Import specific tools that are being used
 import { callActor, callActorGetDataset, getActorsAsTools } from './actor.js';
+import { getDataset, getDatasetItems } from './dataset.js';
+import { getUserDatasetsList } from './dataset_collection.js';
 import { fetchApifyDocsTool } from './fetch-apify-docs.js';
 import { getActorDetailsTool } from './get-actor-details.js';
-import { addTool, helpTool } from './helpers.js';
+import { addTool } from './helpers.js';
+import { getKeyValueStore, getKeyValueStoreKeys, getKeyValueStoreRecord } from './key_value_store.js';
+import { getUserKeyValueStoresList } from './key_value_store_collection.js';
+import { getActorRun, getActorRunLog } from './run.js';
+import { getUserRunsList } from './run_collection.js';
 import { searchApifyDocsTool } from './search-apify-docs.js';
 import { searchActors } from './store_collection.js';
 
 export const defaultTools = [
-    // abortActorRun,
-    // actorDetailsTool,
-    // getActor,
-    // getActorLog,
-    // getActorRun,
-    // getDataset,
-    // getDatasetItems,
-    // getKeyValueStore,
-    // getKeyValueStoreKeys,
-    // getKeyValueStoreRecord,
-    // getUserRunsList,
-    // getUserDatasetsList,
-    // getUserKeyValueStoresList,
     getActorDetailsTool,
-    helpTool,
     searchActors,
-    searchApifyDocsTool,
-    fetchApifyDocsTool,
 ];
+
+export const featureTools = {
+    docs: [
+        searchApifyDocsTool,
+        fetchApifyDocsTool,
+    ],
+    runs: [
+        getActorRun,
+        getUserRunsList,
+        getActorRunLog,
+    ],
+    storage: [
+        getDataset,
+        getDatasetItems,
+        getKeyValueStore,
+        getKeyValueStoreKeys,
+        getKeyValueStoreRecord,
+        getUserDatasetsList,
+        getUserKeyValueStoresList,
+    ],
+};
 
 export const betaTools = [
     callActor,
@@ -33,13 +44,10 @@ export const betaTools = [
 
 export const addRemoveTools = [
     addTool,
-    // removeTool,
 ];
 
 // Export only the tools that are being used
 export {
-    addTool,
-    // removeTool,
     getActorsAsTools,
     callActorGetDataset,
 };

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,5 @@
 // Import specific tools that are being used
+import type { ToolCategory } from '../types.js';
 import { callActor, callActorGetDataset, getActorsAsTools } from './actor.js';
 import { getDataset, getDatasetItems } from './dataset.js';
 import { getUserDatasetsList } from './dataset_collection.js';
@@ -12,12 +13,7 @@ import { getUserRunsList } from './run_collection.js';
 import { searchApifyDocsTool } from './search-apify-docs.js';
 import { searchActors } from './store_collection.js';
 
-export const defaultTools = [
-    getActorDetailsTool,
-    searchActors,
-];
-
-export const featureTools = {
+export const toolCategories = {
     docs: [
         searchApifyDocsTool,
         fetchApifyDocsTool,
@@ -36,10 +32,19 @@ export const featureTools = {
         getUserDatasetsList,
         getUserKeyValueStoresList,
     ],
+    preview: [
+        callActor,
+    ],
 };
+export const toolCategoriesEnabledByDefault: ToolCategory[] = [
+    'docs',
+];
 
-export const betaTools = [
-    callActor,
+export const defaultTools = [
+    getActorDetailsTool,
+    searchActors,
+    // Add the tools from the enabled categories
+    ...toolCategoriesEnabledByDefault.map((key) => toolCategories[key]).flat(),
 ];
 
 export const addRemoveTools = [

--- a/src/tools/run.ts
+++ b/src/tools/run.ts
@@ -59,7 +59,7 @@ const GetRunLogArgs = z.object({
  * https://docs.apify.com/api/v2/actor-run-get
  *  /v2/actor-runs/{runId}/log{?token}
  */
-export const getActorLog: ToolEntry = {
+export const getActorRunLog: ToolEntry = {
     type: 'internal',
     tool: {
         name: HelperTools.ACTOR_RUNS_LOG,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ import type { ActorDefaultRunOptions, ActorDefinition, ActorStoreList, PricingIn
 
 import type { ACTOR_PRICING_MODEL } from './const.js';
 import type { ActorsMcpServer } from './mcp/server.js';
+import type { featureTools } from './tools/index.js';
 
 export interface ISchemaProperties {
     type: string;
@@ -213,6 +214,8 @@ export interface InternalTool extends ToolBase {
     call: (toolArgs: InternalToolArgs) => Promise<object>;
 }
 
+export type FeatureToolKey = keyof typeof featureTools;
+
 export type Input = {
     actors: string[] | string;
     /**
@@ -225,6 +228,7 @@ export type Input = {
     debugActorInput?: unknown;
     /** Enable beta features flag */
     beta?: boolean | string;
+    tools?: FeatureToolKey[] | string;
 };
 
 // Utility type to get a union of values from an object type

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ import type { ActorDefaultRunOptions, ActorDefinition, ActorStoreList, PricingIn
 
 import type { ACTOR_PRICING_MODEL } from './const.js';
 import type { ActorsMcpServer } from './mcp/server.js';
-import type { featureTools } from './tools/index.js';
+import type { toolCategories } from './tools/index.js';
 
 export interface ISchemaProperties {
     type: string;
@@ -214,7 +214,7 @@ export interface InternalTool extends ToolBase {
     call: (toolArgs: InternalToolArgs) => Promise<object>;
 }
 
-export type FeatureToolKey = keyof typeof featureTools;
+export type ToolCategory = keyof typeof toolCategories;
 
 export type Input = {
     actors: string[] | string;
@@ -226,9 +226,8 @@ export type Input = {
     maxActorMemoryBytes?: number;
     debugActor?: string;
     debugActorInput?: unknown;
-    /** Enable beta features flag */
-    beta?: boolean | string;
-    tools?: FeatureToolKey[] | string;
+    /** Tool categories to include */
+    tools?: ToolCategory[] | string;
 };
 
 // Utility type to get a union of values from an object type

--- a/src/utils/tools-loader.ts
+++ b/src/utils/tools-loader.ts
@@ -4,8 +4,8 @@
  */
 
 import { defaults } from '../const.js';
-import { addRemoveTools, betaTools, featureTools, getActorsAsTools } from '../tools/index.js';
-import type { FeatureToolKey, Input, ToolEntry } from '../types.js';
+import { addRemoveTools, getActorsAsTools, toolCategories } from '../tools/index.js';
+import type { Input, ToolCategory, ToolEntry } from '../types.js';
 
 /**
  * Load tools based on the provided Input object.
@@ -37,16 +37,11 @@ export async function loadToolsFromInput(
         tools.push(...addRemoveTools);
     }
 
-    // Add beta tools if enabled
-    if (input.beta) {
-        tools.push(...betaTools);
-    }
-
-    // Add feature tools based on the input
+    // Add tools from enabled categories
     if (input.tools) {
         const toolKeys = Array.isArray(input.tools) ? input.tools : [input.tools];
         for (const toolKey of toolKeys) {
-            const keyTools = featureTools[toolKey as FeatureToolKey] || [];
+            const keyTools = toolCategories[toolKey as ToolCategory] || [];
             tools.push(...keyTools);
         }
     }

--- a/src/utils/tools-loader.ts
+++ b/src/utils/tools-loader.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared logic for loading tools based on Input type.
+ * This eliminates duplication between stdio.ts and processParamsGetTools.
+ */
+
+import { defaults } from '../const.js';
+import { addRemoveTools, betaTools, featureTools, getActorsAsTools } from '../tools/index.js';
+import type { FeatureToolKey, Input, ToolEntry } from '../types.js';
+
+/**
+ * Load tools based on the provided Input object.
+ * This function is used by both the stdio.ts and the processParamsGetTools function.
+ *
+ * @param input The processed Input object
+ * @param apifyToken The Apify API token
+ * @param useDefaultActors Whether to use default actors if no actors are specified
+ * @returns An array of tool entries
+ */
+export async function loadToolsFromInput(
+    input: Input,
+    apifyToken: string,
+    useDefaultActors = false,
+): Promise<ToolEntry[]> {
+    let tools: ToolEntry[] = [];
+
+    // Load actors as tools
+    if (input.actors && (Array.isArray(input.actors) ? input.actors.length > 0 : input.actors)) {
+        const actors = Array.isArray(input.actors) ? input.actors : [input.actors];
+        tools = await getActorsAsTools(actors, apifyToken);
+    } else if (useDefaultActors) {
+        // Use default actors if no actors are specified and useDefaultActors is true
+        tools = await getActorsAsTools(defaults.actors, apifyToken);
+    }
+
+    // Add tools for adding/removing actors if enabled
+    if (input.enableAddingActors) {
+        tools.push(...addRemoveTools);
+    }
+
+    // Add beta tools if enabled
+    if (input.beta) {
+        tools.push(...betaTools);
+    }
+
+    // Add feature tools based on the input
+    if (input.tools) {
+        const toolKeys = Array.isArray(input.tools) ? input.tools : [input.tools];
+        for (const toolKey of toolKeys) {
+            const keyTools = featureTools[toolKey as FeatureToolKey] || [];
+            tools.push(...keyTools);
+        }
+    }
+
+    return tools;
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -5,11 +5,13 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { expect } from 'vitest';
 
 import { HelperTools } from '../src/const.js';
+import type { FeatureToolKey } from '../src/types.js';
 
 export interface McpClientOptions {
     actors?: string[];
     enableAddingActors?: boolean;
     enableBeta?: boolean; // Optional, used for beta features
+    tools?: FeatureToolKey[]; // Optional, used for feature tools
 }
 
 export async function createMcpSseClient(
@@ -20,7 +22,7 @@ export async function createMcpSseClient(
         throw new Error('APIFY_TOKEN environment variable is not set.');
     }
     const url = new URL(serverUrl);
-    const { actors, enableAddingActors, enableBeta } = options || {};
+    const { actors, enableAddingActors, enableBeta, tools } = options || {};
     if (actors) {
         url.searchParams.append('actors', actors.join(','));
     }
@@ -29,6 +31,9 @@ export async function createMcpSseClient(
     }
     if (enableBeta !== undefined) {
         url.searchParams.append('beta', enableBeta.toString());
+    }
+    if (tools && tools.length > 0) {
+        url.searchParams.append('tools', tools.join(','));
     }
 
     const transport = new SSEClientTransport(
@@ -59,7 +64,7 @@ export async function createMcpStreamableClient(
         throw new Error('APIFY_TOKEN environment variable is not set.');
     }
     const url = new URL(serverUrl);
-    const { actors, enableAddingActors, enableBeta } = options || {};
+    const { actors, enableAddingActors, enableBeta, tools } = options || {};
     if (actors) {
         url.searchParams.append('actors', actors.join(','));
     }
@@ -68,6 +73,9 @@ export async function createMcpStreamableClient(
     }
     if (enableBeta !== undefined) {
         url.searchParams.append('beta', enableBeta.toString());
+    }
+    if (tools && tools.length > 0) {
+        url.searchParams.append('tools', tools.join(','));
     }
 
     const transport = new StreamableHTTPClientTransport(
@@ -96,7 +104,7 @@ export async function createMcpStdioClient(
     if (!process.env.APIFY_TOKEN) {
         throw new Error('APIFY_TOKEN environment variable is not set.');
     }
-    const { actors, enableAddingActors, enableBeta } = options || {};
+    const { actors, enableAddingActors, enableBeta, tools } = options || {};
     const args = ['dist/stdio.js'];
     if (actors) {
         args.push('--actors', actors.join(','));
@@ -107,6 +115,10 @@ export async function createMcpStdioClient(
     if (enableBeta !== undefined) {
         args.push('--beta', enableBeta.toString());
     }
+    if (tools && tools.length > 0) {
+        args.push('--tools', tools.join(','));
+    }
+
     const transport = new StdioClientTransport({
         command: 'node',
         args,

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -5,13 +5,12 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { expect } from 'vitest';
 
 import { HelperTools } from '../src/const.js';
-import type { FeatureToolKey } from '../src/types.js';
+import type { ToolCategory } from '../src/types.js';
 
 export interface McpClientOptions {
     actors?: string[];
     enableAddingActors?: boolean;
-    enableBeta?: boolean; // Optional, used for beta features
-    tools?: FeatureToolKey[]; // Optional, used for feature tools
+    tools?: ToolCategory[]; // Tool categories to include
 }
 
 export async function createMcpSseClient(
@@ -22,15 +21,12 @@ export async function createMcpSseClient(
         throw new Error('APIFY_TOKEN environment variable is not set.');
     }
     const url = new URL(serverUrl);
-    const { actors, enableAddingActors, enableBeta, tools } = options || {};
+    const { actors, enableAddingActors, tools } = options || {};
     if (actors) {
         url.searchParams.append('actors', actors.join(','));
     }
     if (enableAddingActors !== undefined) {
         url.searchParams.append('enableAddingActors', enableAddingActors.toString());
-    }
-    if (enableBeta !== undefined) {
-        url.searchParams.append('beta', enableBeta.toString());
     }
     if (tools && tools.length > 0) {
         url.searchParams.append('tools', tools.join(','));
@@ -64,15 +60,12 @@ export async function createMcpStreamableClient(
         throw new Error('APIFY_TOKEN environment variable is not set.');
     }
     const url = new URL(serverUrl);
-    const { actors, enableAddingActors, enableBeta, tools } = options || {};
+    const { actors, enableAddingActors, tools } = options || {};
     if (actors) {
         url.searchParams.append('actors', actors.join(','));
     }
     if (enableAddingActors !== undefined) {
         url.searchParams.append('enableAddingActors', enableAddingActors.toString());
-    }
-    if (enableBeta !== undefined) {
-        url.searchParams.append('beta', enableBeta.toString());
     }
     if (tools && tools.length > 0) {
         url.searchParams.append('tools', tools.join(','));
@@ -104,16 +97,13 @@ export async function createMcpStdioClient(
     if (!process.env.APIFY_TOKEN) {
         throw new Error('APIFY_TOKEN environment variable is not set.');
     }
-    const { actors, enableAddingActors, enableBeta, tools } = options || {};
+    const { actors, enableAddingActors, tools } = options || {};
     const args = ['dist/stdio.js'];
     if (actors) {
         args.push('--actors', actors.join(','));
     }
     if (enableAddingActors !== undefined) {
         args.push('--enable-adding-actors', enableAddingActors.toString());
-    }
-    if (enableBeta !== undefined) {
-        args.push('--beta', enableBeta.toString());
     }
     if (tools && tools.length > 0) {
         args.push('--tools', tools.join(','));

--- a/tests/unit/input.test.ts
+++ b/tests/unit/input.test.ts
@@ -47,46 +47,6 @@ describe('processInput', () => {
         expect(processed.enableAddingActors).toBe(true);
     });
 
-    it('should disable beta features by default', async () => {
-        const input: Partial<Input> = {
-            beta: undefined,
-        };
-        const processed = processInput(input);
-        expect(processed.beta).toBe(false);
-    });
-
-    it('should disable beta features when beta is false', async () => {
-        const input: Partial<Input> = {
-            beta: false,
-        };
-        const processed = processInput(input);
-        expect(processed.beta).toBe(false);
-    });
-
-    it('should disable beta when beta is "false"', async () => {
-        const input: Partial<Input> = {
-            beta: 'false',
-        };
-        const processed = processInput(input);
-        expect(processed.beta).toBe(false);
-    });
-
-    it('should enable beta features when beta non empty string', async () => {
-        const input: Partial<Input> = {
-            beta: '1',
-        };
-        const processed = processInput(input);
-        expect(processed.beta).toBe(true);
-    });
-
-    it('should enable beta features when beta is true', async () => {
-        const input: Partial<Input> = {
-            beta: true,
-        };
-        const processed = processInput(input);
-        expect(processed.beta).toBe(true);
-    });
-
     it('should keep tools as array of valid featureTools keys', async () => {
         const input: Partial<Input> = {
             actors: ['actor1'],

--- a/tests/unit/input.test.ts
+++ b/tests/unit/input.test.ts
@@ -86,4 +86,40 @@ describe('processInput', () => {
         const processed = processInput(input);
         expect(processed.beta).toBe(true);
     });
+
+    it('should keep tools as array of valid featureTools keys', async () => {
+        const input: Partial<Input> = {
+            actors: ['actor1'],
+            tools: ['docs', 'runs'],
+        };
+        const processed = processInput(input);
+        expect(processed.tools).toEqual(['docs', 'runs']);
+    });
+
+    it('should handle empty tools array', async () => {
+        const input: Partial<Input> = {
+            actors: ['actor1'],
+            tools: [],
+        };
+        const processed = processInput(input);
+        expect(processed.tools).toEqual([]);
+    });
+
+    it('should handle missing tools field (undefined)', async () => {
+        const input: Partial<Input> = {
+            actors: ['actor1'],
+        };
+        const processed = processInput(input);
+        expect(processed.tools).toBeUndefined();
+    });
+
+    it('should include all keys, even invalid ones', async () => {
+        const input: Partial<Input> = {
+            actors: ['actor1'],
+            // @ts-expect-error: purposely invalid key for test
+            tools: ['docs', 'invalidKey', 'storage'],
+        };
+        const processed = processInput(input);
+        expect(processed.tools).toEqual(['docs', 'invalidKey', 'storage']);
+    });
 });


### PR DESCRIPTION
closes https://github.com/apify/actors-mcp-server/issues/166

**Only `docs` tools category is currently enabled by default (always)**

This PR introduces the `tools` (`--tools` or `?tools`) comma separated list param so users can choose which tools are loaded into their MCP session.

Possible values:
- docs: Search and fetch Apify documentation tools.
- runs: Get Actor runs list, run details, and logs from a specific Actor run.
- storage: Access datasets, key-value stores, and their records.

Example:
```
--tools docs,runs
?tools=docs,storage
```

Also vibe refactored the tool loading logic so it's not duplicated in the `stdio.ts`