### PR TITLE
fix: export internals for apify-mcp-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "node": ">=18.0.0"
   },
   "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./internals": "./dist/index-internals.js",
+    "./internals.js": "./dist/index-internals.js"
+  },
   "bin": {
     "actors-mcp-server": "./dist/stdio.js"
   },

--- a/src/index-internals.ts
+++ b/src/index-internals.ts
@@ -1,0 +1,21 @@
+/*
+ This file provides essential internal functions for Apify MCP servers, serving as an internal library.
+*/
+
+import { defaults, HelperTools } from './const.js';
+import { parseInputParamsFromUrl } from './mcp/utils.js';
+import { addRemoveTools, defaultTools, toolCategories, toolCategoriesEnabledByDefault } from './tools/index.js';
+import { actorNameToToolName } from './tools/utils.js';
+import type { ToolCategory } from './types.js';
+
+export {
+    parseInputParamsFromUrl,
+    actorNameToToolName,
+    HelperTools,
+    defaults,
+    defaultTools,
+    addRemoveTools,
+    toolCategories,
+    toolCategoriesEnabledByDefault,
+    type ToolCategory,
+};


### PR DESCRIPTION
Export internals used in `apify-mcp-server` repo to prevent importing from `dist/`.

related to https://github.com/apify/apify-mcp-server/issues/102