### PR TITLE
fix: adding non existent Actor

### DIFF
--- a/src/tools/helpers.ts
+++ b/src/tools/helpers.ts
@@ -60,6 +60,19 @@ export const addTool: ToolEntry = {
                 };
             }
             const tools = await getActorsAsTools([parsed.actor], apifyToken);
+            /**
+             * If no tools were found, return a message that the Actor was not found
+             * instead of returning that non existent tool was added since the
+             * getActorsAsTools function returns an empty array and does not throw an error.
+             */
+            if (tools.length === 0) {
+                return {
+                    content: [{
+                        type: 'text',
+                        text: `Actor ${parsed.actor} not found, no tools were added.`,
+                    }],
+                };
+            }
             const toolsAdded = apifyMcpServer.upsertTools(tools, true);
             await sendNotification({ method: 'notifications/tools/list_changed' });
 

--- a/tests/integration/suite.ts
+++ b/tests/integration/suite.ts
@@ -312,6 +312,20 @@ export function createIntegrationTestsSuite(
             await client.close();
         });
 
+        it('should return no tools were added when adding a non-existent actor', async () => {
+            const client = await createClientFn({ enableAddingActors: true });
+            const nonExistentActor = 'apify/this-actor-does-not-exist';
+            const result = await client.callTool({
+                name: HelperTools.ACTOR_ADD,
+                arguments: { actor: nonExistentActor },
+            });
+            expect(result).toBeDefined();
+            const content = result.content as { text: string }[];
+            expect(content.length).toBeGreaterThan(0);
+            expect(content[0].text).toContain('no tools were added');
+            await client.close();
+        });
+
         it('should be able to add and call Actorized MCP server', async () => {
             const client = await createClientFn({ enableAddingActors: true });
 


### PR DESCRIPTION
Fix MCP behaviour when adding non existent Actor. Return no tool added message instead of that the non existent Actor was added.