### PR TITLE
fix: Actor input transform array items type inference

### DIFF
--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -284,8 +284,8 @@ export function transformActorInputSchemaProperties(input: Readonly<IActorInputS
     const inputClone: IActorInputSchema = structuredClone(input);
     let transformedProperties = markInputPropertiesAsRequired(inputClone);
     transformedProperties = buildApifySpecificProperties(transformedProperties);
-    transformedProperties = filterSchemaProperties(transformedProperties);
     transformedProperties = inferArrayItemsTypeIfMissing(transformedProperties);
+    transformedProperties = filterSchemaProperties(transformedProperties);
     transformedProperties = shortenProperties(transformedProperties);
     transformedProperties = addEnumsToDescriptionsWithExamples(transformedProperties);
     transformedProperties = encodeDotPropertyNames(transformedProperties);

--- a/tests/unit/tools.actor.test.ts
+++ b/tests/unit/tools.actor.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { ACTOR_ENUM_MAX_LENGTH } from '../../src/const.js';
-import { actorNameToToolName, inferArrayItemType, shortenEnum } from '../../src/tools/utils.js';
+import { actorNameToToolName } from '../../src/tools/utils.js';
 
 describe('actors', () => {
     describe('actorNameToToolName', () => {
@@ -26,33 +25,6 @@ describe('actors', () => {
             const longName = 'a'.repeat(70);
             const expected = 'a'.repeat(64);
             expect(actorNameToToolName(longName)).toBe(expected);
-        });
-
-        it('infers array item type from editor', () => {
-            const property = {
-                type: 'array',
-                editor: 'stringList',
-                title: '',
-                description: '',
-                enum: [],
-                default: '',
-                prefill: '',
-            };
-            expect(inferArrayItemType(property)).toBe('string');
-        });
-
-        it('shorten enum list', () => {
-            const enumList: string[] = [];
-            const wordLength = 10;
-            const wordCount = 30;
-
-            for (let i = 0; i < wordCount; i++) {
-                enumList.push('a'.repeat(wordLength));
-            }
-
-            const shortenedList = shortenEnum(enumList);
-
-            expect(shortenedList?.length || 0).toBe(ACTOR_ENUM_MAX_LENGTH / wordLength);
         });
     });
 });


### PR DESCRIPTION
This PR fixes the Actor input transform issue where the MCP server did not properly build the `items` sub-property for `array` type input properties. This was caused by a misordering of the transform steps - we filtered out `editor` before building `items`, which requires the `editor` field. Also added a test for this case to prevent this in the future.